### PR TITLE
Reduce space requirements for `SimpleCurl::transform` to i8

### DIFF
--- a/curl/src/curl.rs
+++ b/curl/src/curl.rs
@@ -1,9 +1,10 @@
+use trytes::Trit;
 use trytes::Trinary;
 
 /// All implementations of `Curl` must implement this trait.
 pub trait Curl {
-    /// Absorb a `Trinary` into the sponge
-    fn absorb(&mut self, trinary: Trinary);
+    /// Absorb a `&[Trit]` into the sponge
+    fn absorb(&mut self, trits: &[Trit]);
     /// Squeeze the sponge and return a `Trinary` with `tritCount` trits
     fn squeeze(&mut self, trit_count: usize) -> Trinary;
 }

--- a/curl/src/simple.rs
+++ b/curl/src/simple.rs
@@ -45,18 +45,17 @@ impl SimpleCurl {
                     scratchpad_index -= 365;
                 };
                 self.state[state_index] = TRUTH_TABLE[(scratchpad[scratchpad_index_save] +
-                                                       scratchpad[scratchpad_index] * 3 +
-                                                       4) as
-                                                      usize];
+                                                           scratchpad[scratchpad_index] * 3 +
+                                                           4) as
+                                                          usize];
             }
         }
     }
 }
 
 impl Curl for SimpleCurl {
-    fn absorb(&mut self, trinary: Trinary) {
-        let mut len = trinary.len_trits();
-        let trits = trinary.trits();
+    fn absorb(&mut self, trits: &[Trit]) {
+        let mut len = trits.len();
         let mut offset = 0;
         loop {
             let to = offset + if len < HASH_LENGTH { len } else { HASH_LENGTH };

--- a/curl/src/simple.rs
+++ b/curl/src/simple.rs
@@ -28,7 +28,7 @@ impl Clone for SimpleCurl {
 impl SimpleCurl {
     fn transform(&mut self) {
         // Required memory space type for computation
-        type Space = i32;
+        type Space = i8;
 
         let mut scratchpad: [Space; STATE_LENGTH] = [0; STATE_LENGTH];
         let mut scratchpad_index: usize = 0;

--- a/curl/src/tests.rs
+++ b/curl/src/tests.rs
@@ -59,7 +59,7 @@ pub mod testsuite {
                 .chars()
                 .collect();
 
-            curl.absorb(trans);
+            curl.absorb(&trans.trits());
             let hash: Trinary = curl.squeeze(HASH_LENGTH);
 
             assert_eq!(hash, ex_hash);


### PR DESCRIPTION
No need to waste memory.

Also changes the `trait Curl` to absorb a `&[Trit]` instead of a `Trinary`.