### PR TITLE
Iterator for iterating over all trits in a Trinary without allocating all upfront

### DIFF
--- a/trytes/src/bct.rs
+++ b/trytes/src/bct.rs
@@ -1,0 +1,65 @@
+use std::iter::FromIterator;
+
+use constants::BCTrit;
+use constants::Trit;
+use trinary::Trinary;
+
+/// Converts an `Iterator<Trit>` to an instance of `Trinary`
+impl<'a> FromIterator<&'a BCTrit> for Trinary {
+    fn from_iter<I: IntoIterator<Item = &'a BCTrit>>(iter: I) -> Self {
+
+        let mut trits: Vec<Trit> = Vec::new();
+
+        for t in iter {
+            trits.push(bct_to_trit(*t));
+        }
+
+        trits.into_iter().collect()
+    }
+}
+
+#[inline(always)]
+pub fn trit_to_bct(t: Trit) -> BCTrit {
+    let high = usize::max_value();
+    let low = usize::min_value();
+    match t {
+        -1 => (high, low),
+        1 => (low, high),
+        0 => (high, high),
+        _ => panic!("Invalid Trit: {:?}", t),
+    }
+}
+
+#[inline(always)]
+pub fn bct_to_trit(t: BCTrit) -> Trit {
+    let high = usize::max_value();
+    let low = usize::min_value();
+
+    if t == (high, low) {
+        return -1;
+    } else if t == (low, high) {
+        return 1;
+    } else if t == (high, high) {
+        return 0;
+    } else {
+        panic!("Invalid BCTrit: {:?}", t);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_trit_bc() {
+        let t: Trinary = "H".chars().collect(); // trit: [-1,0,1]
+        let bct = t.bctrits();
+
+        let high = usize::max_value();
+        let low = usize::min_value();
+
+        assert_eq!(bct, vec![(high, low), (high, high), (low, high)]);
+
+        let tbc: Trinary = bct.iter().collect();
+        assert_eq!(t, tbc);
+    }
+}

--- a/trytes/src/constants.rs
+++ b/trytes/src/constants.rs
@@ -1,5 +1,7 @@
 /// Type alias for `Trit`
 pub type Trit = i8;
+/// Binary coded trit, see http://homepage.divms.uiowa.edu/~jones/ternary/bct.shtml
+pub type BCTrit = (usize, usize);
 /// Default hash length in trits (81*3)
 pub const HASH_LENGTH: usize = 243;
 pub const RADIX: Trit = 3;

--- a/trytes/src/iter.rs
+++ b/trytes/src/iter.rs
@@ -1,0 +1,59 @@
+use constants::*;
+use trinary::*;
+use util::*;
+
+/// Constructs an iterator over all trits in a `&Trinary`
+impl<'a> IntoIterator for &'a Trinary {
+    type Item = Trit;
+    type IntoIter = TrinaryIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        TrinaryIterator {
+            trinary: self,
+            index: 0,
+            emitted: 0,
+            trits_index: 0,
+        }
+    }
+}
+
+pub struct TrinaryIterator<'a> {
+    trinary: &'a Trinary,
+    index: usize,
+    emitted: usize,
+    trits_index: usize,
+}
+
+impl<'a> Iterator for TrinaryIterator<'a> {
+    type Item = Trit;
+    fn next(&mut self) -> Option<Trit> {
+        if self.emitted == self.trinary.len_trits() {
+            return None;
+        }
+
+        if self.trits_index >= TRITS_PER_BYTE {
+            self.index += 1;
+            self.trits_index = 0;
+        }
+
+        let trit = byte_to_trits(self.trinary.bytes()[self.index])[self.trits_index];
+        self.trits_index += 1;
+        self.emitted += 1;
+
+        Some(trit)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+    use super::*;
+    #[test]
+    fn test_iter() {
+        let trinary = Trinary::from_str("ABCDASDQWEDASDAKJFASD9").unwrap();
+        let trits_ex = trinary.trits();
+        let trits_iter : Vec<Trit> = (&trinary).into_iter().collect();
+
+        assert_eq!(trits_ex, trits_iter);
+    }
+}

--- a/trytes/src/lib.rs
+++ b/trytes/src/lib.rs
@@ -10,6 +10,7 @@ pub mod trinary;
 pub mod string;
 pub mod trits;
 pub mod iter;
+pub mod bct;
 
 pub use constants::TRYTE_ALPHABET;
 pub use constants::Trit;

--- a/trytes/src/lib.rs
+++ b/trytes/src/lib.rs
@@ -9,9 +9,14 @@ pub mod trinary;
 // trinary traits
 pub mod string;
 pub mod trits;
+pub mod iter;
 
-pub use constants::*;
+pub use constants::TRYTE_ALPHABET;
+pub use constants::Trit;
+pub use constants::HASH_LENGTH;
+
 pub use trinary::*;
 pub use string::*;
 pub use trits::*;
+pub use iter::*;
 

--- a/trytes/src/mappings.rs
+++ b/trytes/src/mappings.rs
@@ -1,7 +1,7 @@
 use constants::*;
 
 /// Hardcoded mappings from `u8` to 5 `Trit`s
-pub const BYTE_TO_TRITS_MAPPINGS: [[Trit; TRITS_PER_BYTE]; HASH_LENGTH] = [[0, 0, 0, 0, 0],
+pub static BYTE_TO_TRITS_MAPPINGS: [[Trit; TRITS_PER_BYTE]; HASH_LENGTH] = [[0, 0, 0, 0, 0],
                                                                            [0, 0, 0, 0, 1],
                                                                            [0, 0, 0, 1, -1],
                                                                            [0, 0, 0, 1, 0],
@@ -246,7 +246,7 @@ pub const BYTE_TO_TRITS_MAPPINGS: [[Trit; TRITS_PER_BYTE]; HASH_LENGTH] = [[0, 0
                                                                            [0, 0, 0, 0, -1]];
 
 /// Hardcoded tryte to `Trit` mappings
-pub const TRYTE_TO_TRITS_MAPPINGS: [[Trit; TRITS_PER_TRYTE]; TRYTE_SPACE] = [[0, 0, 0],
+pub static TRYTE_TO_TRITS_MAPPINGS: [[Trit; TRITS_PER_TRYTE]; TRYTE_SPACE] = [[0, 0, 0],
                                                                              [1, 0, 0],
                                                                              [-1, 1, 0],
                                                                              [0, 1, 0],

--- a/trytes/src/trinary.rs
+++ b/trytes/src/trinary.rs
@@ -26,12 +26,12 @@ impl fmt::Debug for Trinary {
 
 /// Default trait for serialisation into a `Trinary`
 trait IntoTrinary {
-    fn trinary(self) -> Trinary;
+    fn trinary(&self) -> Trinary;
 }
 
 impl IntoTrinary for Trinary {
-    fn trinary(self) -> Trinary {
-        self
+    fn trinary(&self) -> Trinary {
+        self.clone()
     }
 }
 
@@ -50,13 +50,13 @@ impl Trinary {
         let mut cnt = self.length;
 
         for b in &self.bytes {
-            let mut t = byte_to_trits(*b);
+            let t = byte_to_trits(*b);
 
             if cnt > TRITS_PER_BYTE {
-                trits.append(&mut t);
+                trits.extend_from_slice(t);
             } else {
                 let i = TRITS_PER_BYTE - cnt;
-                trits.extend(t[i..TRITS_PER_BYTE].iter().cloned());
+                trits.extend_from_slice(&t[i..TRITS_PER_BYTE]);
                 break;
             }
             cnt -= TRITS_PER_BYTE;
@@ -70,9 +70,9 @@ impl Trinary {
         self.trits().chunks(3).map(trits_to_char).collect()
     }
 
-    /// Returns the `Vec<u8>` representation of this `Trinary` 
-    pub fn bytes(&self) -> Vec<u8> {
-        self.bytes.clone()
+    /// Returns the `&[u8]` representation of this `Trinary` 
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
     }
 
     /// Length of this `Trinary` in trits 
@@ -83,6 +83,11 @@ impl Trinary {
     /// Length of this `Trinary` in trytes
     pub fn len_chars(&self) -> usize {
         self.length / TRITS_PER_TRYTE
+    }
+
+    /// Length of this `Trinary` in bytes
+    pub fn len_bytes(&self) -> usize {
+        self.bytes.len()
     }
 }
 

--- a/trytes/src/trinary.rs
+++ b/trytes/src/trinary.rs
@@ -1,13 +1,13 @@
 use std::fmt;
 use constants::*;
 use util::*;
+use bct::*;
 
 /// `Trinary` holds an array of trinary values.
 #[derive(Clone, Eq, PartialEq)]
 pub struct Trinary {
     bytes: Vec<u8>,
-    length: usize
-    
+    length: usize,
 }
 
 impl fmt::Display for Trinary {
@@ -21,7 +21,6 @@ impl fmt::Debug for Trinary {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Trinary({}, {}, {:?})", self, self.length, self.bytes)
     }
-    
 }
 
 /// Default trait for serialisation into a `Trinary`
@@ -40,11 +39,11 @@ impl Trinary {
     pub fn new(bytes: Vec<u8>, length: usize) -> Trinary {
         Trinary {
             bytes: bytes,
-            length: length
+            length: length,
         }
     }
 
-    /// Returns a `Vec<Trit>` representation of this `Trinary` 
+    /// Returns a `Vec<Trit>` representation of this `Trinary`
     pub fn trits(&self) -> Vec<Trit> {
         let mut trits: Vec<Trit> = Vec::new();
         let mut cnt = self.length;
@@ -65,17 +64,26 @@ impl Trinary {
         trits
     }
 
-    /// Returns a `Vec<char>` of the trytes of this `Trinary` 
+    /// Returns a binary-coded representation of the trits of this `Trinary`.
+    /// See http://homepage.divms.uiowa.edu/~jones/ternary/bct.shtml for further details.
+    pub fn bctrits(&self) -> Vec<BCTrit> {
+        self.trits()
+            .into_iter()
+            .map(trit_to_bct)
+            .collect()
+    }
+
+    /// Returns a `Vec<char>` of the trytes of this `Trinary`
     pub fn chars(&self) -> Vec<char> {
         self.trits().chunks(3).map(trits_to_char).collect()
     }
 
-    /// Returns the `&[u8]` representation of this `Trinary` 
+    /// Returns the `&[u8]` representation of this `Trinary`
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
 
-    /// Length of this `Trinary` in trits 
+    /// Length of this `Trinary` in trits
     pub fn len_trits(&self) -> usize {
         self.length
     }
@@ -90,6 +98,3 @@ impl Trinary {
         self.bytes.len()
     }
 }
-
-
-

--- a/trytes/src/util.rs
+++ b/trytes/src/util.rs
@@ -20,9 +20,7 @@ pub fn trits_to_byte(trits: &[Trit]) -> u8 {
 }
 
 /// Converts a byte to `Vec<Trit>`
-pub fn byte_to_trits(bu: u8) -> Vec<Trit> {
-    let mut out: Vec<Trit> = Vec::new();
-
+pub fn byte_to_trits(bu: u8) -> &'static [Trit; TRITS_PER_BYTE] {
     let b = bu as i8;
     let bpos: usize = (if b < 0 {
                            (b as isize) + (HASH_LENGTH as isize)
@@ -30,8 +28,7 @@ pub fn byte_to_trits(bu: u8) -> Vec<Trit> {
                            b as isize
                        }) as usize;
 
-    out.extend_from_slice(&BYTE_TO_TRITS_MAPPINGS[bpos]);
-    out
+    &BYTE_TO_TRITS_MAPPINGS[bpos]
 }
 
 /// Converts a slice of trits to a tryte


### PR DESCRIPTION
Iterator for iterating over all trits in a Trinary without allocating all upfront.
Fixes #13