### PR TITLE
feature/simple_curl_2

### DIFF
--- a/bindings/src/curl/pair.rs
+++ b/bindings/src/curl/pair.rs
@@ -15,7 +15,7 @@ pub fn curl_pair_new() -> *mut c_void {
 
 #[no_mangle]
 pub fn curl_pair_delete(c_curl: *mut c_void) {
-    let boxed: Box<Curl<BCTrit>> = unsafe { Box::from_raw(c_curl as *mut Curl<BCTrit>) };
+    unsafe { Box::from_raw(c_curl as *mut Curl<BCTrit>) };
 }
 
 #[no_mangle]

--- a/bindings/src/curl/simple.rs
+++ b/bindings/src/curl/simple.rs
@@ -16,7 +16,7 @@ pub fn curl_simple_new() -> *mut c_void {
 #[no_mangle]
 pub fn curl_simple_delete(c_curl: *mut c_void) {
     // Deallocate c_curl
-    let boxed: Box<Curl<Trit>> = unsafe { Box::from_raw(c_curl as *mut Curl<Trit>) };
+    unsafe { Box::from_raw(c_curl as *mut Curl<Trit>) };
 }
 
 #[no_mangle]

--- a/curl/src/curl.rs
+++ b/curl/src/curl.rs
@@ -53,7 +53,6 @@ where
         }
 
         out.extend_from_slice(&self.state[0..(trit_count - hash_count * HASH_LENGTH)]);
-        Sponge::transform(self);
 
         out
     }

--- a/curl/src/lib.rs
+++ b/curl/src/lib.rs
@@ -1,4 +1,6 @@
+#![cfg(test)]
 #![feature(test)]
+
 #![feature(alloc)]
 #![no_std]
 extern crate alloc as collections;

--- a/curl/src/lib.rs
+++ b/curl/src/lib.rs
@@ -1,6 +1,5 @@
-#![cfg(test)]
+#![allow(unused_features)]
 #![feature(test)]
-
 #![feature(alloc)]
 #![no_std]
 extern crate alloc as collections;

--- a/curl/src/pair.rs
+++ b/curl/src/pair.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use collections::Vec;
-
 use constants::*;
 use trytes::*;
 use curl::*;

--- a/curl/src/simple.rs
+++ b/curl/src/simple.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use collections::Vec;
 use constants::*;
 use trytes::*;
 use curl::*;

--- a/curl/src/simple.rs
+++ b/curl/src/simple.rs
@@ -30,7 +30,6 @@ impl Sponge for Curl<Trit> {
 
     #[cfg(not(feature = "parallel"))]
     fn transform(&mut self) {
-        let mut scratchpad_index: usize = 0;
         let mut state_clone: [Trit; STATE_LENGTH] = [0; STATE_LENGTH];
 
         for _ in 0..NUMBER_OF_ROUNDS {
@@ -39,16 +38,6 @@ impl Sponge for Curl<Trit> {
                     TRUTH_TABLE[(self.state[TRANSFORM_INDICES[state_index]] +
                                      (self.state[TRANSFORM_INDICES[state_index + 1]] << 2) +
                                      5) as usize];
-                /*let scratchpad_index_save = scratchpad_index;
-                if scratchpad_index < 365 {
-                    scratchpad_index += 364;
-                } else {
-                    scratchpad_index -= 365;
-                };
-                state_clone[state_index] = TRUTH_TABLE[(self.state[scratchpad_index_save] +
-                                                            (self.state[scratchpad_index] << 2) +
-                                                            5) as
-                                                           usize];*/
             }
 
             self.state.copy_from_slice(&state_clone);

--- a/sign/src/iss.rs
+++ b/sign/src/iss.rs
@@ -154,5 +154,7 @@ mod test {
         let key = key(subseed);
         let key_digest = digest_key(key);
         let address = address(key_digest);
+
+        address.len_trits();
     }
 }


### PR DESCRIPTION
This saves another 3% per iteration.

Looking at the generated assembly and comparing it with equivalent C, it doesn't look as if there's much more potential for optimisations here on our end.
Our Rust code is already pretty much identical to the C one.

Using copy_from_slice and unsafe Vec::set_len instead of extend_from_slice has no impact.

Here's to hoping that Rust will improve :tada:!