### PR TITLE
collections crate was renamed to alloc upstream

### DIFF
--- a/bindings/src/main.rs
+++ b/bindings/src/main.rs
@@ -2,8 +2,10 @@
 #![feature(alloc)]
 #![feature(lang_items)]
 #![feature(link_args)]
-#![feature(core_intrinsics)]
 #![no_std]
+
+#![cfg(not(test))]
+#![feature(core_intrinsics)]
 
 extern crate alloc;
 
@@ -13,7 +15,6 @@ extern crate iota_sign;
 extern crate iota_trytes;
 extern crate iota_curl;
 
-use core::intrinsics;
 
 pub mod util;
 pub mod sign;
@@ -29,15 +30,18 @@ extern "C" {}
 // These functions are used by the compiler, but not
 // for a bare-bones hello world. These are normally
 // provided by libstd.
+#[cfg(not(test))]
 #[lang = "eh_personality"]
 #[no_mangle]
 pub extern "C" fn rust_eh_personality() {}
 
 // This function may be needed based on the compilation target.
+#[cfg(not(test))]
 #[lang = "eh_unwind_resume"]
 #[no_mangle]
 pub extern "C" fn rust_eh_unwind_resume() {}
 
+#[cfg(not(test))]
 #[lang = "panic_fmt"]
 #[no_mangle]
 pub extern "C" fn rust_begin_panic(
@@ -45,7 +49,7 @@ pub extern "C" fn rust_begin_panic(
     _file: &'static str,
     _line: u32,
 ) -> ! {
-    unsafe { intrinsics::abort() }
+    unsafe { core::intrinsics::abort() }
 }
 
 #[start]

--- a/curl/src/curl.rs
+++ b/curl/src/curl.rs
@@ -1,6 +1,6 @@
 use constants::*;
 use trytes::*;
-use collections::Vec;
+use alloc::Vec;
 
 /// All implementations of `Curl` must implement this trait.
 

--- a/curl/src/lib.rs
+++ b/curl/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(alloc)]
 #![no_std]
-extern crate alloc as collections;
+extern crate alloc;
 
 
 #[cfg(feature = "parallel")]

--- a/curl/src/pair.rs
+++ b/curl/src/pair.rs
@@ -18,7 +18,7 @@ fn step(first: BCTrit, second: BCTrit) -> BCTrit {
 impl Sponge for Curl<BCTrit> {
     #[cfg(feature = "parallel")]
     fn transform(&mut self) {
-        use collections::Vec;
+        use alloc::Vec;
 
         let mut scratchpad: Vec<BCTrit> = self.state.iter().map(|&c| (c.0, c.1)).collect();
 

--- a/pow/src/lib.rs
+++ b/pow/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
-
 #![feature(alloc)]
-extern crate alloc as collections;
+
+extern crate alloc;
 
 extern crate iota_trytes as trytes;
 extern crate iota_curl as curl;

--- a/pow/src/pow.rs
+++ b/pow/src/pow.rs
@@ -1,5 +1,5 @@
 use trytes::*;
-use collections::String;
+use alloc::String;
 
 pub enum PoWError {
     /// Input trinary is not of `TRANSACTION_LENGTH`

--- a/sign/src/iss.rs
+++ b/sign/src/iss.rs
@@ -1,6 +1,6 @@
 // This is a straight clone off https://github.com/Come-from-Beyond/ISS/blob/master/src/cfb/iss/ISS.java for testing purposes.
 // XXX DO NOT EXPECT THE METHODS OR CODE IN THIS MODULE TO PERSIST XXX
-use collections::Vec;
+use alloc::Vec;
 
 use trytes::*;
 use trytes::constants::RADIX;

--- a/sign/src/lib.rs
+++ b/sign/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 #![feature(alloc)]
-extern crate alloc as collections;
+extern crate alloc;
 
 extern crate iota_trytes as trytes;
 extern crate iota_curl as curl;

--- a/trytes/src/bct.rs
+++ b/trytes/src/bct.rs
@@ -1,4 +1,4 @@
-use collections::Vec;
+use alloc::Vec;
 use core::iter::FromIterator;
 
 use constants::BCTrit;
@@ -51,7 +51,7 @@ pub fn bct_to_trit(t: BCTrit) -> Trit {
 mod test {
     use super::*;
     use trinary::IntoTrits;
-    use collections::*;
+    use alloc::*;
 
     #[test]
     fn test_trit_bc() {

--- a/trytes/src/iter.rs
+++ b/trytes/src/iter.rs
@@ -47,7 +47,7 @@ impl<'a> Iterator for TrinaryIterator<'a> {
 #[cfg(test)]
 mod test {
     use core::str::FromStr;
-    use collections::Vec;
+    use alloc::Vec;
     
     use super::*;
     #[test]

--- a/trytes/src/lib.rs
+++ b/trytes/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(alloc)]
 
-extern crate alloc as collections;
+extern crate alloc;
 // constant definitions
 pub mod constants;
 pub mod mappings;

--- a/trytes/src/multiplex/demux.rs
+++ b/trytes/src/multiplex/demux.rs
@@ -5,7 +5,7 @@ use multiplex::constants::*;
 use core::cmp::min;
 use core::ops::Index;
 use core::iter::IntoIterator;
-use collections::Vec;
+use alloc::Vec;
 
 
 pub struct TrinaryDemultiplexer {

--- a/trytes/src/multiplex/mux.rs
+++ b/trytes/src/multiplex/mux.rs
@@ -4,7 +4,7 @@ use multiplex::constants::*;
 
 use core::ops::AddAssign;
 use core::ops::Index;
-use collections::Vec;
+use alloc::Vec;
 
 pub struct TrinaryMultiplexer<'a> {
     trinaries: Vec<&'a Trinary>,

--- a/trytes/src/string.rs
+++ b/trytes/src/string.rs
@@ -1,4 +1,4 @@
-use collections::vec::Vec;
+use alloc::vec::Vec;
 use core::iter::FromIterator;
 use core::str::FromStr;
 
@@ -62,7 +62,7 @@ impl FromStr for Trinary {
 mod tests {
     use super::*;
     use TrinaryParseError::*;
-    use collections::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn only_valid_chars() {

--- a/trytes/src/trinary.rs
+++ b/trytes/src/trinary.rs
@@ -1,5 +1,5 @@
-use collections::vec::Vec;
-use collections::string::String;
+use alloc::vec::Vec;
+use alloc::string::String;
 
 use core::fmt;
 use constants::*;

--- a/trytes/src/trits.rs
+++ b/trytes/src/trits.rs
@@ -1,4 +1,4 @@
-use collections::Vec;
+use alloc::Vec;
 use core::iter::FromIterator;
 
 use trinary::*;
@@ -30,8 +30,8 @@ impl FromIterator<Trit> for Trinary {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use collections::*;
-    use collections::string::ToString;
+    use alloc::*;
+    use alloc::string::ToString;
 
     #[test]
     fn from_iterator_trit() {


### PR DESCRIPTION
No changes in features, just fixed warnings and bench build for bindings in addition to 
renaming `collections` to `alloc` everywhere.